### PR TITLE
disable warning C4351

### DIFF
--- a/build
+++ b/build
@@ -285,7 +285,7 @@ function compile_vstudio() {
     CL_CMD=${CL_CMD:="cl.exe"}
     LINK_CMD="link.exe"
 
-    clflags=("${clflags[@]}" "//nologo" "//EHsc" "//W4" "//WX" "//wd4996" "//wd4068" "//wd4100" "//Zc:forScope")
+    clflags=("${clflags[@]}" "//nologo" "//EHsc" "//W4" "//WX" "//wd4351" "//wd4996" "//wd4068" "//wd4100" "//Zc:forScope")
 
     link_flags=("${link_flags[@]}" //nologo)
 


### PR DESCRIPTION
http://msdn.microsoft.com/en-us/library/1ywe7hcy.aspx is a warning that shows up to warn people about behaviour where MSVC changed. Since we are starting in the new beautiful world of non-legacy code, it makes no sense to keep it.
